### PR TITLE
Add meta data for index page - title, description, keywords

### DIFF
--- a/icms_version.php
+++ b/icms_version.php
@@ -9,7 +9,7 @@
  * @since 1.0
  * @author marcan aka Marc-André Lanciault <marcan@smartfactory.ca>
  * @package imblogging
- * 
+ *
  */
 defined("ICMS_ROOT_PATH") || die("ICMS root path not defined");
 
@@ -193,6 +193,30 @@ $modversion['config'][] = array(
 	'formtype' => 'textbox',
 	'valuetype' => 'text',
 	'default' => 5);
+
+$modversion['config'][] = array(
+    'name' => 'show_mod_name_breadcrumb',
+    'title' => '_MI_IMBLOGGING_MODNAME_BREADCRUMB',
+    'description' => '_MI_IMBLOGGING_MODNAME_BREADCRUMB_DSC',
+    'formtype' => 'yesno',
+    'valuetype' => 'int',
+    'default' => 1);
+
+$modversion['config'][] = array(
+	'name' => 'module_meta_keywords',
+	'title' => '_MI_IMBLOGGING_KEYWORDS',
+	'description' => '_MI_IMBLOGGING_KEYWORDS_DSC',
+	'formtype' => 'textbox',
+	'valuetype' => 'text',
+	'default' => '');
+
+$modversion['config'][] = array(
+	'name' => 'module_meta_description',
+	'title' => '_MI_IMBLOGGING_METADESC',
+	'description' => '_MI_IMBLOGGING_METADESC_DSC',
+	'formtype' => 'textbox',
+	'valuetype' => 'text',
+	'default' => '');
 
 /**
  * Comments information

--- a/language/english/common.php
+++ b/language/english/common.php
@@ -30,7 +30,7 @@ define("_CO_IMBLOGGING_POST_ALL_POSTS", "All posts");
 define("_CO_IMBLOGGING_POST_POST_REFERENCE", "Reference of this post");
 
 define("_CO_IMBLOGGING_POST_INFO", "Published by %s on %s.");
-define("_CO_IMBLOGGING_POST_FROM_USER", "All posts of %s");
+define("_CO_IMBLOGGING_POST_FROM_USER", "All posts by %s");
 define("_CO_IMBLOGGING_POST_FROM_MONTH", "All posts made in %s %u");
 define("_CO_IMBLOGGING_POST_COMMENTS_INFO", "%d comments");
 define("_CO_IMBLOGGING_POST_NO_COMMENT", "No comment");

--- a/language/english/modinfo.php
+++ b/language/english/modinfo.php
@@ -8,7 +8,7 @@
  * @license http://www.gnu.org/licenses/old-licenses/gpl-2.0.html GNU General Public License (GPL)
  * @since 1.0
  * @author marcan aka Marc-André Lanciault <marcan@smartfactory.ca>
- * 
+ *
  */
 if (!defined("ICMS_ROOT_PATH")) die("ICMS root path not defined");
 
@@ -26,6 +26,14 @@ define("_MI_IMBLOGGING_POSTERGR", "Groups allowed to posts");
 define("_MI_IMBLOGGING_POSTERGRDSC", "Select the groups which are allowed to create new posts. Please note that a user belonging to one of these groups will be able to post directly on the site. The module currently has no moderation feature.");
 define("_MI_IMBLOGGING_LIMIT", "Posts limit");
 define("_MI_IMBLOGGING_LIMITDSC", "Number of posts to display on user side.");
+
+// For IPF Metagen
+define('_MI_IMBLOGGING_MODNAME_BREADCRUMB', 'Include Module Name in Breadcrumb and Title');
+define('_MI_IMBLOGGING_MODNAME_BREADCRUMB_DSC', 'Do you want the module name included as part of the paget title?');
+define('_MI_IMBLOGGING_METADESC', "Module's Meta Description");
+define('_MI_IMBLOGGING_METADESC_DSC', 'The meta description to be used for the main page of the module');
+define('_MI_IMBLOGGING_KEYWORDS', 'Default keywords for the module');
+define('_MI_IMBLOGGING_KEYWORDS_DSC', 'The meta keywords to be used for the main page of the module');
 
 // Blocks
 define("_MI_IMBLOGGING_POSTRECENT", "Recent posts");

--- a/language/german/modinfo.php
+++ b/language/german/modinfo.php
@@ -6,7 +6,7 @@
  * @license http://www.gnu.org/licenses/old-licenses/gpl-2.0.html GNU General Public License (GPL)
  * @since 1.0
  * @author marcan aka Marc-André Lanciault <marcan@smartfactory.ca>
- * 
+ *
  */
 if (!defined("ICMS_ROOT_PATH")) die("ICMS root path not defined");
 
@@ -24,6 +24,14 @@ define("_MI_IMBLOGGING_POSTERGR", "Gruppen die Beiträge schreiben dürfen");
 define("_MI_IMBLOGGING_POSTERGRDSC", "Wählen Sie die Gruppen aus, denen erlaubt ist neue Beiträge zu schreiben. Beachten Sie welche Mitglieder in welche Gruppe sich befinden! Das Modul verfügt derzeit über keine Moderatorenfunktion.");
 define("_MI_IMBLOGGING_LIMIT", "Beiträge anzeigen");
 define("_MI_IMBLOGGING_LIMITDSC", "Anzahl der Beiträge die in der Webseite angezeigt werden sollen.");
+
+// For IPF Metagen
+define('_MI_IMBLOGGING_MODNAME_BREADCRUMB', 'Include Module Name in Breadcrumb and Title');
+define('_MI_IMBLOGGING_MODNAME_BREADCRUMB_DSC', 'Do you want the module name included as part of the paget title?');
+define('_MI_IMBLOGGING_METADESC', "Module's Meta Description");
+define('_MI_IMBLOGGING_METADESC_DSC', 'The meta description to be used for the main page of the module');
+define('_MI_IMBLOGGING_KEYWORDS', 'Default keywords for the module');
+define('_MI_IMBLOGGING_KEYWORDS_DSC', 'The meta keywords to be used for the main page of the module');
 
 // Blocks
 define("_MI_IMBLOGGING_POSTRECENT", "Neue Beiträge");

--- a/language/nederlands/modinfo.php
+++ b/language/nederlands/modinfo.php
@@ -7,7 +7,7 @@
  * @since 1.0
  * @author marcan aka Marc-André Lanciault <marcan@smartfactory.ca>
  * @translation    McDonald
- * 
+ *
  */
 if (!defined("ICMS_ROOT_PATH")) die("ICMS root path not defined");
 
@@ -25,6 +25,14 @@ define("_MI_IMBLOGGING_POSTERGR", "Groeps toegestaan om te posten");
 define("_MI_IMBLOGGING_POSTERGRDSC", "Selecteer de groepen die nieuwe berichten mogen inzenden. Gelieve op te merken op dat een gebruiker die tot één van deze groepen behoort direct op de plaats zal kunnen posten. De module heeft momenteel geen modificatie optie.");
 define("_MI_IMBLOGGING_LIMIT", "Berichten limiet");
 define("_MI_IMBLOGGING_LIMITDSC", "Aantal berichten weer te geven aan gebruikers zijde.");
+
+// For IPF Metagen
+define('_MI_IMBLOGGING_MODNAME_BREADCRUMB', 'Include Module Name in Breadcrumb and Title');
+define('_MI_IMBLOGGING_MODNAME_BREADCRUMB_DSC', 'Do you want the module name included as part of the paget title?');
+define('_MI_IMBLOGGING_METADESC', "Module's Meta Description");
+define('_MI_IMBLOGGING_METADESC_DSC', 'The meta description to be used for the main page of the module');
+define('_MI_IMBLOGGING_KEYWORDS', 'Default keywords for the module');
+define('_MI_IMBLOGGING_KEYWORDS_DSC', 'The meta keywords to be used for the main page of the module');
 
 // Blocks
 define("_MI_IMBLOGGING_POSTRECENT", "Recente berichten");

--- a/language/persian/modinfo.php
+++ b/language/persian/modinfo.php
@@ -7,7 +7,7 @@
  * @license http://www.gnu.org/licenses/old-licenses/gpl-2.0.html GNU General Public License (GPL)
  * @since 1.0
  * @author Sina Asghari (aka stranger) <pesian_stranger@users.sourceforge.net>
- * 
+ *
  */
 if (!defined("ICMS_ROOT_PATH")) die("ICMS root path not defined");
 
@@ -25,6 +25,14 @@ define("_MI_IMBLOGGING_POSTERGR", "گروه‌های مجاز به نویسند�
 define("_MI_IMBLOGGING_POSTERGRDSC", "گروه‌های مجاز به نوشتن مطالب را تعیین کنید. این ماژول در حال حاضر قابلیت مدیریتی ندارد.");
 define("_MI_IMBLOGGING_LIMIT", "محدودیت پیام‌ها");
 define("_MI_IMBLOGGING_LIMITDSC", "تعداد پیام‌های نمایان در قسمت کاربری.");
+
+// For IPF Metagen
+define('_MI_IMBLOGGING_MODNAME_BREADCRUMB', 'Include Module Name in Breadcrumb and Title');
+define('_MI_IMBLOGGING_MODNAME_BREADCRUMB_DSC', 'Do you want the module name included as part of the paget title?');
+define('_MI_IMBLOGGING_METADESC', "Module's Meta Description");
+define('_MI_IMBLOGGING_METADESC_DSC', 'The meta description to be used for the main page of the module');
+define('_MI_IMBLOGGING_KEYWORDS', 'Default keywords for the module');
+define('_MI_IMBLOGGING_KEYWORDS_DSC', 'The meta keywords to be used for the main page of the module');
 
 // Blocks
 define("_MI_IMBLOGGING_POSTRECENT", "آخرین نوشته‌ها");

--- a/language/portuguesebr/modinfo.php
+++ b/language/portuguesebr/modinfo.php
@@ -6,7 +6,7 @@
  * @license http://www.gnu.org/licenses/old-licenses/gpl-2.0.html GNU General Public License (GPL)
  * @since 1.0
  * @author marcan aka Marc-André Lanciault <marcan@smartfactory.ca>
- * 
+ *
  * @translation        GibaPhp - http://br.impresscms.org
  */
 if (!defined("ICMS_ROOT_PATH")) die("O caminho para o raiz do site não foi definido");
@@ -25,6 +25,14 @@ define("_MI_IMBLOGGING_POSTERGR", "Grupos permitidos para enviar Blogs");
 define("_MI_IMBLOGGING_POSTERGRDSC", "Selecione os grupos que têm permissão para criar novos Blogs. Observe que um usuário que pertença a um destes grupos será capaz de enviar diretamente um Blog para o site. O módulo atualmente ainda não tem nenhum recurso moderação.");
 define("_MI_IMBLOGGING_LIMIT", "Limite de Blogs");
 define("_MI_IMBLOGGING_LIMITDSC", "Número de Blogs visualizados na área de usuário.");
+
+// For IPF Metagen
+define('_MI_IMBLOGGING_MODNAME_BREADCRUMB', 'Include Module Name in Breadcrumb and Title');
+define('_MI_IMBLOGGING_MODNAME_BREADCRUMB_DSC', 'Do you want the module name included as part of the paget title?');
+define('_MI_IMBLOGGING_METADESC', "Module's Meta Description");
+define('_MI_IMBLOGGING_METADESC_DSC', 'The meta description to be used for the main page of the module');
+define('_MI_IMBLOGGING_KEYWORDS', 'Default keywords for the module');
+define('_MI_IMBLOGGING_KEYWORDS_DSC', 'The meta keywords to be used for the main page of the module');
 
 // Blocks
 define("_MI_IMBLOGGING_POSTRECENT", "Blogs Recentes");

--- a/language/russian/modinfo.php
+++ b/language/russian/modinfo.php
@@ -25,6 +25,14 @@ define("_MI_IMBLOGGING_POSTERGRDSC", "Выбор групп, которым ра
 define("_MI_IMBLOGGING_LIMIT", "Ограничения сообщений");
 define("_MI_IMBLOGGING_LIMITDSC", "Кол-во сообщений для показа пользователям.");
 
+// For IPF Metagen
+define('_MI_IMBLOGGING_MODNAME_BREADCRUMB', 'Include Module Name in Breadcrumb and Title');
+define('_MI_IMBLOGGING_MODNAME_BREADCRUMB_DSC', 'Do you want the module name included as part of the paget title?');
+define('_MI_IMBLOGGING_METADESC', "Module's Meta Description");
+define('_MI_IMBLOGGING_METADESC_DSC', 'The meta description to be used for the main page of the module');
+define('_MI_IMBLOGGING_KEYWORDS', 'Default keywords for the module');
+define('_MI_IMBLOGGING_KEYWORDS_DSC', 'The meta keywords to be used for the main page of the module');
+
 // Blocks
 define("_MI_IMBLOGGING_POSTRECENT", "Новейшие сообщения");
 define("_MI_IMBLOGGING_POSTRECENTDSC", "Показать самые новые сообщения");

--- a/language/spanish/modinfo.php
+++ b/language/spanish/modinfo.php
@@ -6,7 +6,7 @@
  * @license http://www.gnu.org/licenses/old-licenses/gpl-2.0.html GNU General Public License (GPL)
  * @since 1.0
  * @author marcan aka Marc-André Lanciault <marcan@smartfactory.ca>
- * 
+ *
  */
 if (!defined("ICMS_ROOT_PATH")) die("ICMS root path not defined");
 
@@ -24,6 +24,14 @@ define("_MI_IMBLOGGING_POSTERGR", "Grupos a los que se permite publicar artícul
 define("_MI_IMBLOGGING_POSTERGRDSC", "Seleccione los grupos de usuarios que pueden publicar nuevos artículos. Tenga en cuenta que un usuario perteneciente a cualquiera de los grupos que elija podrá publicar directamente en el sitio web y que el módulo actualmente no tiene la característica de moderar los envios..");
 define("_MI_IMBLOGGING_LIMIT", "Límite de artículos");
 define("_MI_IMBLOGGING_LIMITDSC", "Número de artículos que se mostrarán en el sitio.");
+
+// For IPF Metagen
+define('_MI_IMBLOGGING_MODNAME_BREADCRUMB', 'Include Module Name in Breadcrumb and Title');
+define('_MI_IMBLOGGING_MODNAME_BREADCRUMB_DSC', 'Do you want the module name included as part of the paget title?');
+define('_MI_IMBLOGGING_METADESC', "Module's Meta Description");
+define('_MI_IMBLOGGING_METADESC_DSC', 'The meta description to be used for the main page of the module');
+define('_MI_IMBLOGGING_KEYWORDS', 'Default keywords for the module');
+define('_MI_IMBLOGGING_KEYWORDS_DSC', 'The meta keywords to be used for the main page of the module');
 
 // Blocks
 define("_MI_IMBLOGGING_POSTRECENT", "Artículos recientes");


### PR DESCRIPTION
The index page renders different content, depending on the arguments - a list of all posts, posts in a category, posts by an author. This adds configuration settings for the module to set defaults for these, and also uses the data from categories (imTagging) and the author bio